### PR TITLE
Fix SHA versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ resolver = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 num = { version = "0.4"}
-sha3 = "0.10"
-sha2 = "0.10"
-blake2 = "0.10"
+sha3 = "=0.10.6"
+sha2 = "=0.10.6"
+blake2 = "=0.10.6"
 k256 = { version = "0.11", features = ["arithmetic", "ecdsa"] }
 static_assertions = "1"
 zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_defs.git", branch = "main" }


### PR DESCRIPTION
There was a new release of SHA (0.10.7) which actually changed the size of some fields, causing compile errors.

In this PR, I'm setting the version to 0.10.6, which we did in internal repo too.