### PR TITLE
Grow heap bounds on return from near call frame

### DIFF
--- a/src/opcodes/execution/ret.rs
+++ b/src/opcodes/execution/ret.rs
@@ -242,6 +242,14 @@ impl<const N: usize, E: VmEncodingMode<N>> DecodedOpcode<N, E> {
             // just use a saved value
         }
 
+        // grow memory on near call
+        if finished_callstack.is_local_frame == true {
+            if finished_callstack.heap_bound >= next_context.heap_bound {
+                next_context.heap_bound = finished_callstack.heap_bound;
+                next_context.aux_heap_bound = finished_callstack.aux_heap_bound;
+            }
+        }
+
         // and set flag on panic
         if inner_variant == RetOpcode::Panic {
             vm_state.local_state.flags.overflow_or_less_than_flag = true;


### PR DESCRIPTION
# What ❔

Ensure heap bounds are increased if a near call frame exceeds the allotted space. 

## Why ❔

This wasn't being done properly and could cause issues with memory management.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
