### PR TITLE
Fixing typo in AUX heap page

### DIFF
--- a/src/reference_impls/memory.rs
+++ b/src/reference_impls/memory.rs
@@ -741,7 +741,7 @@ impl Memory for SimpleMemory {
             );
 
             // We do not need to clean up the page at this point.
-            current_frame_indirections_to_cleanup.remove(&current_heap_page);
+            current_frame_indirections_to_cleanup.remove(&current_aux_heap_page);
 
             previous_frame_indirections_to_cleanup.insert(current_aux_heap_page);
 


### PR DESCRIPTION
# What ❔

* Fixing typo in AUX heap page

## Why ❔

* This caused the page to be removed a lot earlier, causing witness generation to fail.
